### PR TITLE
Fix US tx freq

### DIFF
--- a/packet_forwarder/global_conf.json.sx1250.US915
+++ b/packet_forwarder/global_conf.json.sx1250.US915
@@ -17,7 +17,7 @@
             "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": true,
-            "tx_freq_min": 923000000,
+            "tx_freq_min": 903800000,
             "tx_freq_max": 928000000,
             "tx_gain_lut":[
                 {"rf_power": 12, "pa_gain": 0, "pwr_idx": 15},


### PR DESCRIPTION
We POC on Uplink Frequencies, so need to allow 903.9 MHz plus some room for float rounding errors.
