### PR TITLE
Fix rssi offset

### DIFF
--- a/packet_forwarder/global_conf.json.sx1250.AS923
+++ b/packet_forwarder/global_conf.json.sx1250.AS923
@@ -14,7 +14,7 @@
       "enable": true,
       "type": "SX1250",
       "freq": 922400000,
-      "rssi_offset": -207,
+      "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": true,
       "tx_freq_min": 921600000,

--- a/packet_forwarder/global_conf.json.sx1250.AS923
+++ b/packet_forwarder/global_conf.json.sx1250.AS923
@@ -42,7 +42,7 @@
       "enable": true,
       "type": "SX1250",
       "freq": 923100000,
-      "rssi_offset": -207,
+      "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": false
     },

--- a/packet_forwarder/global_conf.json.sx1250.AU915
+++ b/packet_forwarder/global_conf.json.sx1250.AU915
@@ -14,7 +14,7 @@
       "enable": true,
       "type": "SX1250",
       "freq": 917200000,
-      "rssi_offset": -207,
+      "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": true,
       "tx_freq_min": 916700000,

--- a/packet_forwarder/global_conf.json.sx1250.AU915
+++ b/packet_forwarder/global_conf.json.sx1250.AU915
@@ -42,7 +42,7 @@
       "enable": true,
       "type": "SX1250",
       "freq": 917900000,
-      "rssi_offset": -207,
+      "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": false
     },

--- a/packet_forwarder/global_conf.json.sx1250.CN470
+++ b/packet_forwarder/global_conf.json.sx1250.CN470
@@ -42,7 +42,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 487400000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": false
         },

--- a/packet_forwarder/global_conf.json.sx1250.CN470
+++ b/packet_forwarder/global_conf.json.sx1250.CN470
@@ -14,7 +14,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 486600000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": true,
             "tx_freq_min" : 486290000,

--- a/packet_forwarder/global_conf.json.sx1250.CN470
+++ b/packet_forwarder/global_conf.json.sx1250.CN470
@@ -14,7 +14,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 486600000,
-            "rssi_offset": -215.4,
+            "rssi_offset": -207,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": true,
             "tx_freq_min" : 486290000,
@@ -42,7 +42,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 487400000,
-            "rssi_offset": -215.4,
+            "rssi_offset": -207,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": false
         },

--- a/packet_forwarder/global_conf.json.sx1250.EU868
+++ b/packet_forwarder/global_conf.json.sx1250.EU868
@@ -14,7 +14,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 867500000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": true,
             "tx_freq_min": 863000000,
@@ -42,7 +42,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 868500000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": false
         },

--- a/packet_forwarder/global_conf.json.sx1250.US915
+++ b/packet_forwarder/global_conf.json.sx1250.US915
@@ -14,7 +14,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 904300000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": true,
             "tx_freq_min": 902000000,
@@ -42,7 +42,7 @@
             "enable": true,
             "type": "SX1250",
             "freq": 905000000,
-            "rssi_offset": -207,
+            "rssi_offset": -215.4,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
             "tx_enable": false
         },


### PR DESCRIPTION
Reverted changes to the RSSI offset back to -215.4 which is the default used by RAK and the Semtech 1302 base global_conf file to address issue RAK2287 based hotspots displaying consistently higher RSSI values than hotspots with other concentrators