### PR TITLE
Fix timestamp normalization math, fixing rare timestamp bug.

### DIFF
--- a/libloragw/src/loragw_gps.c
+++ b/libloragw/src/loragw_gps.c
@@ -1139,7 +1139,10 @@ int lgw_cnt2utc(struct tref ref, uint32_t count_us, struct timespec *utc) {
     /* now add that delta to reference UTC time */
     fractpart = modf (delta_sec , &intpart);
     tmp = ref.utc.tv_nsec + (long)(fractpart * 1E9);
-    if (tmp < (long)1E9) { /* the nanosecond part doesn't overflow */
+    if (tmp < 0) { /* the nanosecond part has underflown */
+        utc->tv_sec = ref.utc.tv_sec + (time_t)intpart - 1;
+        utc->tv_nsec = tmp + (long)1E9;
+    } else if (tmp < (long)1E9) { /* the nanosecond part hasn't overflown */
         utc->tv_sec = ref.utc.tv_sec + (time_t)intpart;
         utc->tv_nsec = tmp;
     } else { /* must carry one second */
@@ -1190,7 +1193,10 @@ int lgw_cnt2gps(struct tref ref, uint32_t count_us, struct timespec *gps_time) {
     /* now add that delta to reference GPS time */
     fractpart = modf (delta_sec , &intpart);
     tmp = ref.gps.tv_nsec + (long)(fractpart * 1E9);
-    if (tmp < (long)1E9) { /* the nanosecond part doesn't overflow */
+    if (tmp < 0) { /* the nanosecond part has underflown */
+        gps_time->tv_sec = ref.gps.tv_sec + (time_t)intpart - 1;
+        gps_time->tv_nsec = tmp + (long)1E9;
+    } else if (tmp < (long)1E9) { /* the nanosecond part hasn't overflown */
         gps_time->tv_sec = ref.gps.tv_sec + (time_t)intpart;
         gps_time->tv_nsec = tmp;
     } else { /* must carry one second */


### PR DESCRIPTION
Occasionally the packet forwarder will forward a packet with
an unparsable `time` timestamp attribute because the fractional
part of the seconds field will have a negative sign in it.

An example that I witnessed was the timestamp:

`2020-10-11T22:59:05.-00072Z`

Bugs like this are almost always signs of buggy attempts to
perform arithmetic on `timeval` structures in C without carefully
covering all of the overflow _and_ underflow conditions. Sure
enough, that was the case here.

With this change, the code now properly handles a `tv_nsec`
underflow and should no longer cause other parts of the code to
generate unparsable timestamps like the given example.