### PR TITLE
Update global_conf.json.sx1250.CN470

### DIFF
--- a/packet_forwarder/global_conf.json.sx1250.CN470
+++ b/packet_forwarder/global_conf.json.sx1250.CN470
@@ -13,6 +13,7 @@
         "radio_0": {
             "enable": true,
             "type": "SX1250",
+            "single_input_mode": true,
             "freq": 486600000,
             "rssi_offset": -207,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
@@ -41,6 +42,7 @@
         "radio_1": {
             "enable": true,
             "type": "SX1250",
+            "single_input_mode": true,
             "freq": 487400000,
             "rssi_offset": -207,
             "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},


### PR DESCRIPTION
The receiver of CN470 LoRa module is in single input mode, while the LoRa module of EU868 and US915 is in differential input mode. Setting CN470 to differential mode will make the receiver sensitivity worse