### PR TITLE
Revert au915 changes

### DIFF
--- a/packet_forwarder/global_conf.json.sx1250.AU915
+++ b/packet_forwarder/global_conf.json.sx1250.AU915
@@ -13,7 +13,7 @@
     "radio_0": {
       "enable": true,
       "type": "SX1250",
-      "freq": 917100000,
+      "freq": 917200000,
       "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": true,
@@ -41,7 +41,7 @@
     "radio_1": {
       "enable": true,
       "type": "SX1250",
-      "freq": 917800000,
+      "freq": 917900000,
       "rssi_offset": -215.4,
       "rssi_tcomp": {"coeff_a": 0, "coeff_b": 0, "coeff_c": 20.41, "coeff_d": 2162.56, "coeff_e": 0},
       "tx_enable": false
@@ -49,22 +49,22 @@
     "chan_multiSF_0": {
       "enable": true,
       "radio": 0,
-      "if": -300000
+      "if": -400000
     },
     "chan_multiSF_1": {
       "enable": true,
       "radio": 0,
-      "if": -100000
+      "if": -200000
     },
     "chan_multiSF_2": {
       "enable": true,
       "radio": 0,
-      "if": 100000
+      "if": 0
     },
     "chan_multiSF_3": {
       "enable": true,
       "radio": 0,
-      "if": 300000
+      "if": 200000
     },
     "chan_multiSF_4": {
       "enable": true,
@@ -74,22 +74,22 @@
     "chan_multiSF_5": {
       "enable": true,
       "radio": 1,
-      "if": -200000
+      "if": -100000
     },
     "chan_multiSF_6": {
       "enable": true,
       "radio": 1,
-      "if": 0
+      "if": 100000
     },
     "chan_multiSF_7": {
       "enable": true,
       "radio": 1,
-      "if": 200000
+      "if": 300000
     },
     "chan_Lora_std": {
       "enable": true,
-      "radio": 1,
-      "if": 400000,
+      "radio": 0,
+      "if": 300000,
       "bandwidth": 500000,
       "spread_factor": 8
     },


### PR DESCRIPTION
This reverts commit bcc18e9767c9d1ef8758b055413b47ad3cc0434f, which mistook 917.5 MHz "fat channel" as the 4th channel for AU915.