### PR TITLE
gps fix: not processing gps location when using gps via tty

### DIFF
--- a/packet_forwarder/src/lora_pkt_fwd.c
+++ b/packet_forwarder/src/lora_pkt_fwd.c
@@ -3308,6 +3308,8 @@ void thread_gps_tty(void) {
                         frame_size = 0;
                     } else if (latest_msg == UBX_NAV_TIMEGPS) {
                         gps_process_sync();
+                    } else if (latest_msg == UBX_NAV_PVT) {
+                        gps_process_coords();
                     }
                 }
             } else if (serial_buff[rd_idx] == (char)LGW_GPS_NMEA_SYNC_CHAR) {


### PR DESCRIPTION
When using a Concentrator with serial GPS module (tty), the packet forwarder was failing to report gps coordinates correctly, even when the GPS had a true fix. Turns out the function gps_process_coords() was not getting called.